### PR TITLE
Hide movie name in notification.

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -19,6 +19,7 @@ addonIcon = addon.getAddonInfo('icon')
 
 randomType         = addon.getSetting('randomType')
 askForTypeOnLaunch = addon.getSetting('askForTypeOnLaunch')
+showMovieTitle = addon.getSetting('showMovieTitle')
 
 if (askForTypeOnLaunch == 'true'):
   randomType = xbmcgui.Dialog().select(addon.getLocalizedString(32002), [addon.getLocalizedString(32004), addon.getLocalizedString(32005), addon.getLocalizedString(32006), addon.getLocalizedString(32007)])
@@ -31,4 +32,10 @@ else:
   time   = 10000
 
   xbmc.executebuiltin('PlayMedia(%s)'%(movie['file']))
-  xbmc.executebuiltin('Notification(%s, %s %s, %d, %s)'%(addonName,"Playing ",movie['label'],time,addonIcon))
+
+  if (showMovieTitle == 'true'):
+    title = movie['label']
+  else:
+    title = '????????';
+
+  xbmc.executebuiltin('Notification(%s, %s %s, %d, %s)'%(addonName,"Playing ",title,time,addonIcon))

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -7,16 +7,16 @@ msgstr ""
 "Project-Id-Version: XBMC Addons\n"
 "Report-Msgid-Bugs-To: pdnagilum@gmail.com\n"
 "POT-Creation-Date: 2015-12-16 22:00\n"
-"PO-Revision-Date: 2015-12-16 22:00\n"
+"PO-Revision-Date: 2016-05-06 12:45+0100\n"
 "Last-Translator: pdnagilum\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language-Team: \n"
 
-#Add-on messages id=32001 to 32007
-
+# Add-on messages id=32001 to 32007
 msgctxt "#32001"
 msgid "General"
 msgstr ""
@@ -26,7 +26,7 @@ msgid "From which list of movies do you wish to randomize?"
 msgstr ""
 
 msgctxt "#32003"
-msgid "Ask each time the addon in launched"
+msgid "Ask each time the addon is launched"
 msgstr ""
 
 msgctxt "#32004"
@@ -43,4 +43,8 @@ msgstr ""
 
 msgctxt "#32007"
 msgid "Cancel"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Show the movie title"
 msgstr ""

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -14,7 +14,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language-Team: \n"
 
 # Add-on messages id=32001 to 32007
 msgctxt "#32001"

--- a/resources/language/Norwegian/strings.po
+++ b/resources/language/Norwegian/strings.po
@@ -14,7 +14,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: no\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language-Team: \n"
 
 # Add-on messages id=32001 to 32007
 msgctxt "#32001"

--- a/resources/language/Norwegian/strings.po
+++ b/resources/language/Norwegian/strings.po
@@ -7,16 +7,16 @@ msgstr ""
 "Project-Id-Version: XBMC Addons\n"
 "Report-Msgid-Bugs-To: pdnagilum@gmail.com\n"
 "POT-Creation-Date: 2015-12-16 22:00\n"
-"PO-Revision-Date: 2015-12-16 22:00\n"
+"PO-Revision-Date: 2016-05-06 12:45+0100\n"
 "Last-Translator: pdnagilum\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: no\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language-Team: \n"
 
-#Add-on messages id=32001 to 32007
-
+# Add-on messages id=32001 to 32007
 msgctxt "#32001"
 msgid "General"
 msgstr "Generelt"
@@ -26,7 +26,7 @@ msgid "From which list of movies do you wish to randomize?"
 msgstr "Fra hvilken liste med filmer ønsker du å velge tilfeldig fra?"
 
 msgctxt "#32003"
-msgid "Ask each time the addon in launched"
+msgid "Ask each time the addon is launched"
 msgstr "Spør hver gang tillegget starter"
 
 msgctxt "#32004"
@@ -44,3 +44,7 @@ msgstr "Usette"
 msgctxt "#32007"
 msgid "Cancel"
 msgstr "Avbryt"
+
+msgctxt "#32008"
+msgid "Show the movie title"
+msgstr "Vis filmtittel"

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -4,5 +4,6 @@
   <category label="32001">
     <setting label="32002" type="enum" id="randomType" lvalues="32004|32005|32006" />
     <setting label="32003" type="bool" id="askForTypeOnLaunch" default="false" />
+    <setting label="32008" type="bool" id="showMovieTitle" default="true" />
   </category>
 </settings>


### PR DESCRIPTION
Hi

Just thought I would commit a small addition I made to the script. We like the name of the movie that is about to play to be a mystery so I have added an option to hide this in the notification.

Just sending a pull request just in case you wanted to incorporate this feature.

Thanks for writing the add-on, it's very useful when you can't decide what movie to watch :). 

Thanks
Adrian
